### PR TITLE
Update build.gradle

### DIFF
--- a/vividus-plugin-applitools/build.gradle
+++ b/vividus-plugin-applitools/build.gradle
@@ -9,7 +9,12 @@ dependencies {
     implementation project(':vividus-soft-assert')
     implementation project(':vividus-util')
 
-    implementation(group: 'com.applitools', name: 'eyes-images-java5', version: '5.75.3')
+    implementation(group: 'com.applitools', name: 'eyes-images-java5', version: '5.75.3') {
+        // exclude because of 
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+    }
+    implementation(group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.15.0-rc1')
+    
     implementation(group: 'com.applitools', name: 'eyes-selenium-java5', version: '5.77.0')
     implementation platform(group: 'org.slf4j', name: 'slf4j-bom', version: '2.0.17')
     implementation(group: 'org.slf4j', name: 'slf4j-api')


### PR DESCRIPTION
Exclude the Vulnerable Library: Use the exclude block within the eyes-images-java5 dependency declaration to exclude the transitive dependency `com.fasterxml.jackson.core:jackson-core`.

Explicitly Add the Fixed Version: Add the fixed version of `jackson-core (2.15.0-rc1)` as a standalone dependency using the implementation directive.